### PR TITLE
Added Dash webapps to types and fs-manager

### DIFF
--- a/src/FSManager.ts
+++ b/src/FSManager.ts
@@ -1,4 +1,4 @@
-import { WebApp, WebAppType, BokehWebAppParams, ShinyWebAppParams, StandardWebAppParams, WebAppFile } from "./api/webapp";
+import { WebApp, WebAppType, BokehWebAppParams, DashWebAppParams, ShinyWebAppParams, StandardWebAppParams, WebAppFile } from "./api/webapp";
 import { RecipeAndPayload } from "./api/recipe";
 import { WikiArticle } from "./api/wiki";
 import { writeFile, existsSync, mkdirSync, rmdirSync, readdirSync, lstatSync, unlinkSync } from "fs";
@@ -49,6 +49,11 @@ export class FileDetails {
 
         if (webApp.type === WebAppType.BOKEH) {
             const params = webApp.params as BokehWebAppParams;
+            files.push(
+                new FileDetails(WebAppFile.BACKEND, params.python, dir)
+            );
+        } else if (webApp.type === WebAppType.DASH) {
+            const params = webApp.params as DashWebAppParams;
             files.push(
                 new FileDetails(WebAppFile.BACKEND, params.python, dir)
             );

--- a/src/api/webapp.ts
+++ b/src/api/webapp.ts
@@ -11,12 +11,17 @@ export interface WebAppDetails {
 export enum WebAppType {
     SHINY="SHINY",
     BOKEH="BOKEH",
+    DASH="DASH",
     STANDARD="STANDARD",
 }
 
 export interface WebApp extends WebAppDetails {
-    params: BokehWebAppParams | ShinyWebAppParams | StandardWebAppParams;
+    params: BokehWebAppParams | DashWebAppParams | ShinyWebAppParams | StandardWebAppParams;
     versionTag: VersionTag;
+}
+
+export interface DashWebAppParams {
+    python: string;
 }
 
 export interface BokehWebAppParams {
@@ -48,7 +53,7 @@ export enum WebAppFile {
 export function getModifiedWebApp(webApp: WebApp, modifiedFileName: string, newContent: string) {
     switch(modifiedFileName) {
         case WebAppFile.BACKEND:
-            (webApp.params as BokehWebAppParams | StandardWebAppParams).python = newContent;
+            (webApp.params as BokehWebAppParams | DashWebAppParams | StandardWebAppParams).python = newContent;
             break;
         case WebAppFile.UI:
             (webApp.params as ShinyWebAppParams).ui = newContent;


### PR DESCRIPTION
# Description
The addition of Dash webapps inside the VSCode extension has been asked by some customers. Should be pretty straightforward to review.

# How to test?
- Create a Dash Webapp
- Go to VSCode, make sure DSS is connected to it
- List content of the project with the Dash webapp in it
- The Dash webapp folder and backend.py file should appear
- Try editing the file
- The changes should be saved to DSS